### PR TITLE
FB for PCM MPV1 and Prototype for RCC Pump.

### DIFF
--- a/sample-delivery/Library/DUTs/RCC/E_RCC_PUMP_SM_STATES.TcDUT
+++ b/sample-delivery/Library/DUTs/RCC/E_RCC_PUMP_SM_STATES.TcDUT
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <DUT Name="E_RCC_PUMP_SM_STATES" Id="{a096e4d2-f6d5-4703-bc2b-ebe9d5cb1313}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE E_RCC_PUMP_SM_STATES :
+(
+    IDLE := 0,
+    PRESSURE := 1,
+    VACUUM := 2,
+    VENT := 3
+);
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/sample-delivery/Library/Library.plcproj
+++ b/sample-delivery/Library/Library.plcproj
@@ -16,7 +16,7 @@
     <Implicit_Jitter_Distribution>{ee4a008e-3fc6-4185-92b5-c3a57c0f2c5e}</Implicit_Jitter_Distribution>
     <LibraryReferences>{6f5799fa-7bce-4f89-8794-1ee6574da6eb}</LibraryReferences>
     <Company>SLAC - LCLS</Company>
-    <Released>true</Released>
+    <Released>false</Released>
     <Title>LCLS Sample Delivery</Title>
     <ProjectVersion>0.0.0</ProjectVersion>
   </PropertyGroup>
@@ -95,6 +95,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="DUTs\IO_Structs\ST_SerialComm.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="DUTs\RCC\E_RCC_PUMP_SM_STATES.TcDUT">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="DUTs\RCC\E_RCC_STATES.TcDUT">
@@ -205,6 +208,12 @@
     <Compile Include="POUs\Helpers\FB_ShiftByteArray.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\PCM\FB_MPV1.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\PCM\FB_PCM_AIO.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\PCM\FB_PressureControlModule.TcPOU">
       <SubType>Code</SubType>
     </Compile>
@@ -212,6 +221,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\RCC\FB_RCC.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\RCC\FB_RCC_PUMP.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\RCC\FB_RCC_SM.TcPOU">

--- a/sample-delivery/Library/POUs/PCM/FB_MPV1.TcPOU
+++ b/sample-delivery/Library/POUs/PCM/FB_MPV1.TcPOU
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <POU Name="FB_MPV1" Id="{ba3e2f33-c936-4cf9-8e17-0622679aedea}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_MPV1
+(* Pressure Control Module 0-10v control and readback signal *)
+VAR_INPUT
+END_VAR
+VAR_OUTPUT
+END_VAR
+VAR
+    {attribute 'pytmc' := '
+        pv: PropAir:01
+     '}
+    stPropAir1 : ST_Proportionair;
+    {attribute 'pytmc' := '
+        pv: PropAir:02
+     '}
+    stPropAir2 : ST_Proportionair;
+
+    PropAir1 : FB_PCM_AIO;
+    PropAir2 : FB_PCM_AIO;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[PropAir1(iq_stRegProp:=stPropAir1, iDEVICE_MAX_PRESSURE := 100);
+PropAir1(iq_stRegProp:=stPropAir1, iDEVICE_MAX_PRESSURE := 100);]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/sample-delivery/Library/POUs/PCM/FB_PCM_AIO.TcPOU
+++ b/sample-delivery/Library/POUs/PCM/FB_PCM_AIO.TcPOU
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <POU Name="FB_PCM_AIO" Id="{798575c7-8eb6-49c5-b85a-70e9fe016a05}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_PCM_AIO
+(* FUNCTION BLOCK FOR PRESSURE CONTROL MODULES WIT ANALOG IO CONTROL WITH 0-10v SIGNAL *)
+VAR_INPUT
+    iDEVICE_MAX_PRESSURE : INT := 100; // (psi)
+END_VAR
+VAR_OUTPUT
+END_VAR
+VAR
+    iTermBits :INT := 32767;
+END_VAR
+VAR_IN_OUT
+    iq_stRegProp	:	ST_Proportionair;
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[iq_stRegProp.iPressure := REAL_TO_INT(iDEVICE_MAX_PRESSURE * (MAX(0,INT_TO_REAL(iq_stRegProp.i_iPressRB)) / iTermBits));
+iq_stRegProp.iSetpoint := LIMIT(iq_stRegProp.iLoLimit, iq_stRegProp.iSetpoint, iq_stRegProp.iHiLimit);
+iq_stRegProp.q_iPressCt := REAL_TO_INT( (INT_TO_REAL(iq_stRegProp.iSetpoint)/iDEVICE_MAX_PRESSURE)*iTermBits);]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/sample-delivery/Library/POUs/RCC/FB_RCC_PUMP.TcPOU
+++ b/sample-delivery/Library/POUs/RCC/FB_RCC_PUMP.TcPOU
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <POU Name="FB_RCC_PUMP" Id="{ecb6e357-c313-4cb0-8d54-9c6287211993}" SpecialFunc="None">
+    <Declaration><![CDATA[(*This is a funcitonal prototype for in AIR RCC PUMP / L.V. RCC / WIP NAME*)
+FUNCTION_BLOCK FB_RCC_PUMP
+VAR_IN_OUT
+    stRCC_VRC_01 : ST_VRC;
+    stRCC_VRC_02 : ST_VRC;
+    stRCC_VRC_03 : ST_VRC;
+
+    T1 : TIME;
+    T2 : TIME;
+    T3 : TIME;
+
+    bStart 	: BOOL := FALSE;
+    bStop	: BOOL := FALSE;
+
+END_VAR
+VAR_OUTPUT
+END_VAR
+VAR
+    iState 	: INT := E_RCC_PUMP_SM_STATES.IDLE;
+    tTimer1 : TON;
+    tTime : TIME := T#0s;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[tTimer1(IN:=TRUE, PT:= tTime);
+
+IF bStop THEN
+    bStop := FALSE;
+    stRCC_VRC_01.pv_xOPN_SW := FALSE;
+    stRCC_VRC_02.pv_xOPN_SW := FALSE;
+    stRCC_VRC_03.pv_xOPN_SW := FALSE;
+    iState := E_RCC_PUMP_SM_STATES.IDLE;
+END_IF
+
+CASE iState OF
+    E_RCC_PUMP_SM_STATES.IDLE: // IDlE
+
+    IF bStart THEN
+        iState := E_RCC_PUMP_SM_STATES.PRESSURE;
+        bStart := FALSE;
+        tTime := T1;
+        tTimer1(IN:=FALSE); // RESTART TIMER
+    END_IF
+
+    E_RCC_PUMP_SM_STATES.PRESSURE: // PRESSURE
+
+    stRCC_VRC_01.pv_xOPN_SW := FALSE;
+    stRCC_VRC_02.pv_xOPN_SW := FALSE;
+    stRCC_VRC_03.pv_xOPN_SW := TRUE;
+
+    IF tTimer1.Q THEN
+        iState := E_RCC_PUMP_SM_STATES.VACUUM;
+        tTime := T2;
+        tTimer1(IN:=FALSE); // RESTART TIMER
+    END_IF
+
+    E_RCC_PUMP_SM_STATES.VACUUM: // VACUUM
+
+    stRCC_VRC_01.pv_xOPN_SW := FALSE;
+    stRCC_VRC_02.pv_xOPN_SW := TRUE;
+    stRCC_VRC_03.pv_xOPN_SW := FALSE;
+
+    IF tTimer1.Q THEN
+        iState := E_RCC_PUMP_SM_STATES.VENT;
+        tTime := T3;
+        tTimer1(IN:=FALSE); // RESTART TIMER
+    END_IF
+
+    E_RCC_PUMP_SM_STATES.VENT: // VENT;
+
+    stRCC_VRC_01.pv_xOPN_SW := TRUE;
+    stRCC_VRC_02.pv_xOPN_SW := FALSE;
+    stRCC_VRC_03.pv_xOPN_SW := FALSE;
+
+    IF tTimer1.Q THEN
+        iState := E_RCC_PUMP_SM_STATES.VENT;
+    END_IF
+
+END_CASE]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

This PR introduces the prototype control logic for the RCC (Rapid Cell Cleanout) Pump system, which is currently being tested in ICL.

     RCC Pump State Machine (FB_RCC_PUMP)
     Implements a 4-state sequential controller for operating 3 valves (VRC_01, VRC02, VRC03):
     - IDLE → PRESSURE → VACUUM → VENT → IDLE
     - Each state transition is timer-driven (T1, T2, T3) allowing configurable dwell times
     - Triggered via bStart signal, reset via bStop signal

     New Types & Modules

     - E_RCC_PUMP_SM_STATES — Enumeration defining the 4 pump states
     - FB_MPV1 — Pressure Control Module function block managing two PropAir devices (PropAir:01, PropAir:02) via 0-10V analog I/O
     - FB_PCM_AIO — Analog I/O helper that converts between pressure setpoints (psi) and the 0–32767 analog output range, with setpoint clamping within configured limits


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Currently running in ICL.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://confluence.slac.stanford.edu/spaces/PCDS/pages/685814288/WIP+SED+Controls+Overview
## Screenshots (if appropriate):

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to fixed versions and not ``Always Newest``
- [x] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
